### PR TITLE
Make text fit better in notation view.

### DIFF
--- a/src/components/ChessBoardIcon.tsx
+++ b/src/components/ChessBoardIcon.tsx
@@ -60,6 +60,7 @@ export const hoverColors = {
   slate700: "hover:fill-slate-700",
   slate800: "hover:fill-slate-800",
   slate900: "hover:fill-slate-900",
+  none: "",
 };
 
 export const strokeColors = {
@@ -76,7 +77,7 @@ export type ChessBoardIconProps = {
   alt?: string;
   className?: string;
   strokeColor?: keyof typeof strokeColors;
-  hoverColor?: keyof typeof hoverColors | null;
+  hoverColor?: keyof typeof hoverColors;
 } & Omit<ImageProps, "src" | "alt" | "fill">;
 
 export function ChessBoardIcon({
@@ -86,11 +87,10 @@ export function ChessBoardIcon({
   alt = "Checkerboard Icon",
   className = "",
   strokeColor = "none",
-  hoverColor = null,
+  hoverColor = "none",
   ...imageProps
 }: ChessBoardIconProps) {
   // Return correct component with props
-  hoverColor = hoverColor || lightColor;
   const props = {
     ...imageProps,
     className: [

--- a/src/components/chess/PGNViewer.tsx
+++ b/src/components/chess/PGNViewer.tsx
@@ -134,8 +134,8 @@ export default function PGNViewer({
           leftContainerStyle="justify-left items-center gap-2 xl:gap-4 pt-1 xl:pt-0"
         />
       </div>
-      <div className="w-1/2 p-2 pb-2 lg:p-5 lg:pb-2 flex flex-col justify-between items-end-safe">
-        <div aria-label="Notation Viewer" className="w-full">
+      <div className="w-1/2 p-1 pt-2 pl-2 lg:p-2 lg:pl-4 lg:pt-4 flex flex-col justify-between items-end-safe">
+        <div aria-label="Notation Viewer" className="w-full h-full mb-2">
           {
             <PGNViewerNotation
               variation={mainVariation}

--- a/src/components/chess/PGNViewerNotation.tsx
+++ b/src/components/chess/PGNViewerNotation.tsx
@@ -46,7 +46,7 @@ export function PGNViewerNotation({
 }: PGNViewerNotationProps) {
   return (
     <>
-      {level > 0 ? <span>( </span> : ""}
+      {level > 0 ? <span> (</span> : ""}
       {variation.moves.map((move: Move, i: number) => {
         const isCurrentMove =
           variation.id === gameState?.variation.id &&
@@ -67,10 +67,10 @@ export function PGNViewerNotation({
             className={`inline ${variationStylesByLevel.get(level) || variationStylesByLevel.get(-1)}`}
           >
             <button
-              className={`p-1 cursor-pointer text-nowrap inline
-                                ${level > 0 && "italic"}
-                                ${isCurrentMove && "font-bold text-primaryblack dark:text-primarywhite bg-secondary dark:bg-secondary-light rounded-lg"}
-                            `}
+              className={`px-1 py-0 sm:py-[1px] xl:py-[3px] cursor-pointer text-nowrap inline outline-none
+                          ${level > 0 && "italic"}
+                          ${(isCurrentMove && "font-bold text-primaryblack dark:text-primarywhite bg-secondary dark:bg-secondary-light rounded-lg border-1 shadow-md") || "border-none"}
+                        `}
               onClick={
                 setGameState &&
                 (() =>
@@ -85,20 +85,18 @@ export function PGNViewerNotation({
               {move_number}
               <span
                 className={`
-                                    ${moveIsGreat(move) && "text-lime-600 dark:text-lime-400"}
-                                    ${moveIsMistake(move) && "text-sky-900 dark:text-sky-200"}
-                                `}
-                dangerouslySetInnerHTML={{
-                  __html: move_text + "&nbsp;",
-                }}
+                              ${moveIsGreat(move) && "text-lime-600 dark:text-lime-400"}
+                              ${moveIsMistake(move) && "text-sky-900 dark:text-sky-200"}
+                          `}
+                dangerouslySetInnerHTML={{ __html: move_text }}
               ></span>
             </button>
             {move.comment ? (
               <span
-                className="text-primary p-1 ml-[-3px]"
+                className="text-primary px-1 ml-[-3px]"
                 aria-label={"Comment: " + move.comment}
               >
-                {move.comment}{" "}
+                {" " + move.comment}
               </span>
             ) : (
               <span> </span>
@@ -114,7 +112,7 @@ export function PGNViewerNotation({
           </div>
         );
       })}
-      {level > 0 ? <span>)</span> : ""}
+      {level > 0 ? <span>) </span> : ""}
     </>
   );
 }


### PR DESCRIPTION
Remove some extra spaces between text elements, and lower vertical padding slightly.

Should help it fit nicer on smaller screens.