### PR TITLE
Multiple variations

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,9 +4,12 @@ export default function About() {
   return (
     <>
       <h1 className="text-primary p-10 text-5xl">HELLO WORLD!</h1>
-      <div className="w-125 flex flex-col gap-3">
+      <div className="w-150 flex flex-col gap-3">
         <h3>About Page!</h3>
-        <PGNViewer pgn="1.e4 c5" puzzle />
+        <PGNViewer
+          pgn="1.e4 e5 (1...c5 {Sicilian} 2. Nf3 d6 3. d4 cxd4 4. Nxd4 Nf6 5. Nc3 a6 {Najdorf} (5...g6 {Dragon}) (5...Nc6 {Classical})) (1...e6 {French})"
+          puzzle
+        />
       </div>
     </>
   );

--- a/src/components/chess/PGNViewer.tsx
+++ b/src/components/chess/PGNViewer.tsx
@@ -9,7 +9,7 @@ import { useEngineAnalysis } from "@/lib/hooks/useEngineAnalysis";
 import { useToggle } from "@/lib/hooks/useToggle";
 import { useVariation } from "@/lib/hooks/useVariation";
 import { startFen } from "@/lib/types/pgnTypes";
-import { sideToMove } from "@/lib/utils/chessUtils";
+import { makeVariationsNested, sideToMove } from "@/lib/utils/chessUtils";
 import { loadPgn } from "@/lib/utils/loadPgn";
 
 import { ChessBoardIcon } from "../ChessBoardIcon";
@@ -59,7 +59,7 @@ export default function PGNViewer({
     enterVariation,
     exitVariation,
     setGameState,
-  } = useVariation(mainVariation);
+  } = useVariation(makeVariationsNested(mainVariation));
 
   // Engine State
   const [stockfishData, stockfishEnabled, setStockfishEnabled] =

--- a/src/components/chess/PGNViewerNotation.tsx
+++ b/src/components/chess/PGNViewerNotation.tsx
@@ -101,9 +101,9 @@ export function PGNViewerNotation({
             ) : (
               <span> </span>
             )}
-            {move.variation && (
+            {move.variations.length > 0 && (
               <PGNViewerNotation
-                variation={move.variation}
+                variation={move.variations[0]}
                 gameState={gameState}
                 setGameState={setGameState}
                 level={level + 1}

--- a/src/components/chess/PGNViewerNotation.tsx
+++ b/src/components/chess/PGNViewerNotation.tsx
@@ -1,3 +1,5 @@
+import { Fragment } from "react";
+
 import {
   GameState,
   Move,
@@ -46,7 +48,6 @@ export function PGNViewerNotation({
 }: PGNViewerNotationProps) {
   return (
     <>
-      {level > 0 ? <span> (</span> : ""}
       {variation.moves.map((move: Move, i: number) => {
         const isCurrentMove =
           variation.id === gameState?.variation.id &&
@@ -101,18 +102,19 @@ export function PGNViewerNotation({
             ) : (
               <span> </span>
             )}
-            {move.variations.length > 0 && (
-              <PGNViewerNotation
-                variation={move.variations[0]}
-                gameState={gameState}
-                setGameState={setGameState}
-                level={level + 1}
-              />
-            )}
+            {move.variations.length > 0 ? <span> (</span> : ""}
+            {move.variations.map((variation, i) => (
+              <Fragment key={variation.id}>
+                <PGNViewerNotation
+                  {...{ variation, gameState, setGameState, level: level + 1 }}
+                />
+                {i < move.variations.length - 1 ? <span>, </span> : ""}
+              </Fragment>
+            ))}
+            {move.variations.length > 0 ? <span>) </span> : ""}
           </div>
         );
       })}
-      {level > 0 ? <span>) </span> : ""}
     </>
   );
 }

--- a/src/components/chess/__tests__/testPGNViewerNotation.tsx
+++ b/src/components/chess/__tests__/testPGNViewerNotation.tsx
@@ -1,4 +1,4 @@
-import { act, getByLabelText, getByText } from "@testing-library/react";
+import { act, getByLabelText, getByText, screen } from "@testing-library/react";
 
 import { container, root } from "@/lib/test/componentTestHelpers";
 import { startFen } from "@/lib/types/pgnTypes";
@@ -61,5 +61,16 @@ describe("Test PGNViewerNotation", () => {
   });
   test("Comment rendered", () => {
     expect(getByText(container, "Hello!")).toBeInTheDocument();
+  });
+
+  test("Flat subvariations", () => {
+    const variation = loadPgn("1. e4 e5 (1...e6) (1...c5)", startFen);
+    act(() =>
+      root.render(
+        <PGNViewerNotation {...{ variation, gameState, setGameState }} />,
+      ),
+    );
+    expect(screen.getByText("e6")).toBeInTheDocument();
+    expect(screen.getByText("c5")).toBeInTheDocument();
   });
 });

--- a/src/lib/hooks/__tests__/testUseVariation.tsx
+++ b/src/lib/hooks/__tests__/testUseVariation.tsx
@@ -25,7 +25,7 @@ describe("Hooks/useVariation", () => {
     const move = variation.moves[halfMoveNum - 1];
     expect(move.move).toBe("Nf3");
     expect(move.moveNumber).toBe(2);
-    expect(move.variation).not.toBeFalsy();
+    expect(move.variations.length).toBeGreaterThan(0);
     expect(variation.parentVariation).toBeNull();
   });
 
@@ -108,11 +108,11 @@ describe("Hooks/useVariation", () => {
     const move = variation.moves[halfMoveNum - 1];
     expect(move.move).toBe("Nf3");
     expect(move.moveNumber).toBe(2);
-    expect(move.variation).not.toBeFalsy();
+    expect(move.variations.length).toBeGreaterThan(0);
     expect(variation.parentVariation).toBeNull();
     // Test trying to leave top level variation
     act(result.current.exitVariation);
-    expect(move.variation).not.toBeFalsy();
+    expect(move.variations.length).toBeGreaterThan(0);
     expect(variation.parentVariation).toBeNull();
   });
 
@@ -139,5 +139,14 @@ describe("Hooks/useVariation", () => {
       })),
     );
     expect(result.current.halfMoveNum).toBe(0);
+  });
+
+  test("Test multiple variations", () => {
+    const variationTree = loadPgn("1. e4 e5 (1... c5) (1... e6)", startFen);
+    ({ result } = renderHook(() => useVariation(variationTree)));
+    const variations = result.current.variation.moves[1].variations;
+    expect(variations.length).toBe(2);
+    expect(variations[0].moves[0].move).toBe("c5");
+    expect(variations[1].moves[0].move).toBe("e6");
   });
 });

--- a/src/lib/hooks/useVariation.tsx
+++ b/src/lib/hooks/useVariation.tsx
@@ -59,11 +59,11 @@ export function useVariation(variation: Variation): VariationState {
         moveNum < variationMoves.length;
         moveNum++
       ) {
-        const variation = variationMoves[moveNum].variation;
-        if (variation) {
+        if (variationMoves[moveNum].variations.length > 0) {
+          const variation = variationMoves[moveNum].variations[0];
           return {
             ...prevState,
-            variation: variation,
+            variation,
             halfMoveNum: 1,
           };
         }

--- a/src/lib/types/pgnTypes.tsx
+++ b/src/lib/types/pgnTypes.tsx
@@ -24,7 +24,7 @@ export type Move = {
   move: string;
   annotation: string;
   comment: string;
-  variation: Variation | null;
+  variations: Array<Variation>;
   arrows: Arrows;
   fullMatch: string;
   fenAfter: string;

--- a/src/lib/types/pgnTypes.tsx
+++ b/src/lib/types/pgnTypes.tsx
@@ -26,7 +26,6 @@ export type Move = {
   comment: string;
   variations: Array<Variation>;
   arrows: Arrows;
-  fullMatch: string;
   fenAfter: string;
 };
 

--- a/src/lib/utils/__tests__/testChessUtils.tsx
+++ b/src/lib/utils/__tests__/testChessUtils.tsx
@@ -1,6 +1,13 @@
+import { inspect } from "util";
+
 import { startFen } from "@/lib/types/pgnTypes";
 
-import { getFen, moveIsGreat, moveIsMistake } from "../chessUtils";
+import {
+  getFen,
+  makeVariationsNested,
+  moveIsGreat,
+  moveIsMistake,
+} from "../chessUtils";
 import { loadPgn } from "../loadPgn";
 
 describe("Test Chess Utilities", () => {
@@ -17,7 +24,7 @@ describe("Test Chess Utilities", () => {
         move: "e4",
         annotation: "",
         comment: "",
-        variation: null,
+        variations: [],
         arrows: [],
         fullMatch: "e4",
         fenAfter: fenAfter,
@@ -52,5 +59,23 @@ describe("Test Chess Utilities", () => {
     expect(moveIsMistake(variation.moves[0])).toBe(true);
     variation.moves[0].annotation = "??";
     expect(moveIsMistake(variation.moves[0])).toBe(true);
+  });
+
+  test.each([
+    ["1. e4 c5 (1...e5) (1...e6)", "1. e4 c5 (1...e5 (1...e6))"],
+    ["1. e4 (1. c4) (1. b3)", "1. e4 (1. c4 (1.b3))"],
+    [
+      "1. e4 c5 (1...e5 (1...e6)) (1...c6)",
+      "1. e4 c5 (1...e5 (1...e6 (1...c6)))",
+    ],
+    [
+      "1. e4 e5 (1...c5 2. Nf3 (2. Nc3) (2. g3)) (1...e6)",
+      "1. e4 e5 (1...c5 (1... e6) 2. Nf3 (2. Nc3 (2. g3)))",
+    ],
+  ])("makeVariationsNested", (flatPgn, nestedPgn) => {
+    const result = makeVariationsNested(loadPgn(flatPgn, startFen));
+    const expected = loadPgn(nestedPgn, startFen);
+
+    expect(inspect(result)).toStrictEqual(inspect(expected));
   });
 });

--- a/src/lib/utils/__tests__/testLoadPgn.tsx
+++ b/src/lib/utils/__tests__/testLoadPgn.tsx
@@ -26,7 +26,7 @@ describe("PGN Parser Test", () => {
       "Annotations Nested",
       (annotations, expected) => {
         const testPgn = "1.e4 e5 (1... c5" + annotations + ")";
-        const variation = loadPgn(testPgn, startFen).moves[1].variation;
+        const variation = loadPgn(testPgn, startFen).moves[1].variations[0];
         expect(variation).not.toBeNull();
 
         if (variation !== null) {
@@ -40,7 +40,7 @@ describe("PGN Parser Test", () => {
       const variation = loadPgn(testPgn, startFen);
       expect(variation.moves[0].annotation).toBe("");
       expect(variation.moves[1].annotation).toBe("");
-      const nestedVariation = variation.moves[1].variation;
+      const nestedVariation = variation.moves[1].variations[0];
       if (nestedVariation) {
         expect(nestedVariation.moves[0].annotation).toBe("");
       }
@@ -68,7 +68,7 @@ describe("PGN Parser Test", () => {
     });
     test.each(arrowTable)("Arrows Nested", (arrows, expected) => {
       const testPgn = "1.e4 e5 (1... c5 " + arrows + ")";
-      const variation = loadPgn(testPgn, startFen).moves[1].variation;
+      const variation = loadPgn(testPgn, startFen).moves[1].variations[0];
       expect(variation).not.toBeNull();
       if (variation !== null) {
         expect(variation.moves[0].arrows).toStrictEqual(expected);
@@ -80,7 +80,7 @@ describe("PGN Parser Test", () => {
       const variation = loadPgn(testPgn, startFen);
       expect(variation.moves[0].arrows).toStrictEqual([]);
       expect(variation.moves[1].arrows).toStrictEqual([]);
-      const nestedVariation = variation.moves[1].variation;
+      const nestedVariation = variation.moves[1].variations[0];
       if (nestedVariation) {
         expect(nestedVariation.moves[0].arrows).toStrictEqual([]);
       }
@@ -101,7 +101,7 @@ describe("PGN Parser Test", () => {
     });
     test.each(commentTable)("Comments Nested", (comment, expected) => {
       const testPgn = "1.e4 e5 (1... c5 " + comment + ")";
-      const variation = loadPgn(testPgn, startFen).moves[1].variation;
+      const variation = loadPgn(testPgn, startFen).moves[1].variations[0];
       expect(variation).not.toBeNull();
       if (variation !== null) {
         expect(variation.moves[0].comment).toStrictEqual(expected);
@@ -113,7 +113,7 @@ describe("PGN Parser Test", () => {
     test("Test Single Variation", () => {
       const testPgn = "1. e4 e5 2. Nf3 (2. f4)";
       const mainVar = loadPgn(testPgn, startFen);
-      const variation = mainVar.moves[2].variation;
+      const variation = mainVar.moves[2].variations[0];
       expect(variation).not.toBeNull();
       expect(variation?.start).toEqual(
         "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
@@ -130,7 +130,7 @@ describe("PGN Parser Test", () => {
     test("Test Nested Variation", () => {
       const testPgn = "1. e4 e5 2. Nf3 (2. f4 (2. Nc3))";
       const mainVar = loadPgn(testPgn, startFen);
-      const variation = mainVar.moves[2].variation?.moves[0].variation;
+      const variation = mainVar.moves[2].variations[0]?.moves[0].variations[0];
       expect(variation).not.toBeNull();
       expect(variation?.start).toEqual(
         "rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2",
@@ -143,7 +143,7 @@ describe("PGN Parser Test", () => {
           "rnbqkbnr/pppp1ppp/8/4p3/4P3/2N5/PPPP1PPP/R1BQKBNR b KQkq - 1 2",
       });
       expect(variation?.parentVariation?.id).toStrictEqual(
-        mainVar.moves[2].variation?.id,
+        mainVar.moves[2].variations[0]?.id,
       );
     });
   });
@@ -156,7 +156,7 @@ describe("PGN Parser Test", () => {
       testPgn,
       "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
     );
-    expect(mainVar.moves[0].variation?.moves[7]).toMatchObject({
+    expect(mainVar.moves[0].variations[0]?.moves[7]).toMatchObject({
       move: "0-0",
       annotation: "! &eplus;",
       comment: "Comment!",

--- a/src/lib/utils/chessUtils.tsx
+++ b/src/lib/utils/chessUtils.tsx
@@ -41,8 +41,47 @@ export function moveIsMistake(move: Move) {
  * @param fen - current position
  *
  * @returns "w" | "b"
- *
  */
 export function sideToMove(fen: string) {
   return new Chess(fen).turn();
+}
+
+/**
+ * Converts subvariations to be nested instead of flat.
+ *
+ * For example, 1. e4 e5 (1...c5) (1...e6) becomes 1. e4 e5 (1...c5 (1...e6))
+ *
+ * @param variation - root variation
+ *
+ * @returns - new variation object with subvariations nested when possible
+ */
+export function makeVariationsNested(
+  variation: Variation,
+  additionalVariations: Array<Variation> = [],
+): Variation {
+  // Return variation if it has no moves
+  if (!variation.moves.length) {
+    return { ...variation };
+  }
+  // Add first move, along with any additional variations
+  const firstMove = { ...variation.moves[0] };
+  const moveVars = firstMove.variations.concat(additionalVariations);
+  if (moveVars.length) {
+    firstMove.variations = [
+      makeVariationsNested(moveVars[0], moveVars.slice(1)),
+    ];
+  }
+
+  // Add additional moves, recursing if they have variation.
+  const moves: Array<Move> = [firstMove];
+  for (const move of variation.moves.slice(1)) {
+    if (move.variations.length > 0) {
+      move.variations = [
+        makeVariationsNested(move.variations[0], move.variations.slice(1)),
+      ];
+    }
+    moves.push({ ...move });
+  }
+
+  return { ...variation, moves: moves };
 }

--- a/src/lib/utils/loadPgn.tsx
+++ b/src/lib/utils/loadPgn.tsx
@@ -138,7 +138,6 @@ export function loadPgn(
       annotation: getAnnotation(token[2]),
       comment: token.groups?.comment ?? "",
       arrows: parseArrows(token.groups?.arrows),
-      fullMatch: token[0],
       fenAfter: game.fen(),
     });
   });

--- a/src/lib/utils/loadPgn.tsx
+++ b/src/lib/utils/loadPgn.tsx
@@ -31,8 +31,13 @@ const annotationLookup = [
 
 // PGN REGEXES
 // Creates Regex for matching content within start/end tags (for example between [], (), or {})
-const genBoundaryRegex = (start: string, end: string, matchName: string) =>
-  new RegExp("(?:" + start + "(?<" + matchName + ">.*?)" + end + ")?");
+const genBoundaryRegex = (
+  start: string,
+  end: string,
+  matchName: string,
+  flags: string = "",
+) =>
+  new RegExp("(?:" + start + "(?<" + matchName + ">.*?)" + end + ")?", flags);
 
 //Optional move number (Number followed by . or ...)
 const moveNumberRegex = /(?:[0-9]*\.+)?/;
@@ -47,10 +52,13 @@ const annotationRegex = /((?:[/!?=+-]+ *|\$[0-9]+ *)*)?/;
 // Order must always be arrows -> comments -> variations
 const arrrowRegex = genBoundaryRegex("\\[", "\\]", "arrows");
 const commentRegex = genBoundaryRegex("\\{", "\\}", "comment");
-const variationRegex = genBoundaryRegex("\\$\\(", "\\$\\)", "variation");
+
+// Support multiple variations -> $(var1$) $(var2$)
+const variationRegex = genBoundaryRegex("\\$\\(", "\\$\\)", "variation", "g");
+const multipleVariationsRegex = /(?<variations>(\$\(.*?\$\)\s*)*)/;
 
 // Parse Move number, move, annotation, arrows, comments, and variations
-// e.g. 2. Nf3! $13 [f3e5red] {Attacks e5} $(2. Bc4?$)
+// e.g. 2. Nf3! $13 [f3e5red] {Attacks e5} $(2. Bc4?$) $(2. Bd3??$)
 const pgnParseRegex = new RegExp(
   [
     moveNumberRegex.source,
@@ -58,7 +66,7 @@ const pgnParseRegex = new RegExp(
     annotationRegex.source,
     arrrowRegex.source,
     commentRegex.source,
-    variationRegex.source,
+    multipleVariationsRegex.source,
   ].join(/\s*/.source),
   "g",
 );
@@ -79,7 +87,7 @@ export function loadPgn(
   parentMove: number = 0,
 ): Variation {
   // Replaces every outermost group of matching parenthesis with $( $), so we can easily match in regex
-  pgn = preParsePgn(pgn);
+  pgn = markPgnVariations(pgn);
 
   // Use chessjs game just to verify pgn moves are legal, since it doesn't support variations or custom pgn starting positions
   const game = new Chess(start);
@@ -87,11 +95,11 @@ export function loadPgn(
   const tokens = [...pgn.matchAll(pgnParseRegex)];
   const moves: Array<Move> = [];
   const currentVariation = {
-    id: id,
-    start: start,
-    moves: moves,
+    id,
+    start,
+    moves,
+    parentMove,
     parentVariation: parentVar,
-    parentMove: parentMove,
   };
   // Use 10000 id numbers for variations on current level, so next level starts 10000 higher
   let newId = id + 10000;
@@ -104,16 +112,31 @@ export function loadPgn(
     //Verify move is legal (replace 0-0 with O-O so either casltling notation works)
     game.move(token[1].replace(/0/g, "O"));
 
+    // Handle variations
+    const variations = [];
+    if (token.groups && token.groups.variations) {
+      // Reparse multiple variation string into each single variation
+      const variationTokens = token.groups.variations.matchAll(variationRegex);
+      for (const variationToken of variationTokens) {
+        const varPgn = variationToken.groups?.variation ?? null;
+
+        // Recursively add variation to the tree
+        if (varPgn) {
+          variations.push(
+            loadPgn(varPgn, beforeFen, ++newId, currentVariation, index + 1),
+          );
+        }
+      }
+    }
+
     // Add parsed move to movelist, recursively calling loadPgn for nested variations
     moves.push({
       color: sideToMove,
-      moveNumber: moveNumber,
+      moveNumber,
+      variations,
       move: token[1],
       annotation: getAnnotation(token[2]),
       comment: token.groups?.comment ?? "",
-      variation: token.groups?.variation
-        ? loadPgn(token[5], beforeFen, ++newId, currentVariation, index + 1)
-        : null,
       arrows: parseArrows(token.groups?.arrows),
       fullMatch: token[0],
       fenAfter: game.fen(),
@@ -157,7 +180,7 @@ function parseArrows(arrowPgn?: string) {
  *
  * @param pgn - the pgn to preprocess
  */
-function preParsePgn(pgn: string): string {
+function markPgnVariations(pgn: string): string {
   let level = 0;
   let inComment = false;
   let start = 0;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2019",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Add support for multiple variations to the PGN parser and react UI.

This was already supported using nested variations but without supporting them directly we can't load most lichess study PGNs directly.

Also added functionality to automatically convert flat variations to nested, as that looks better in smaller, multi-board articles like those I plan to write for the blog.