### PR TITLE
Parse PGN Headers

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -7,11 +7,24 @@ export default function About() {
       <div className="w-150 flex flex-col gap-3">
         <h3>About Page!</h3>
         <PGNViewer
-          pgn={`
-                { So black is threatening unstoppable mate in one move. However white has a strong fight back ! }
-                1. Ng6+!! Kg8 2. Ne7+! Kh8 3. Rxh7+!! Kxh7 4. Rh1# $18 *`}
-          start={"r4r1k/5ppp/8/8/5N2/1Bb5/2P5/1KR4R w - - 0 1"}
-          puzzle
+          pgn={`[Event "Briliant moves quiz: Judit's Polgar brilliancy"]
+          [Result "*"]
+          [Variant "Standard"]
+          [ECO "?"]
+          [Opening "?"]
+          [StudyName "Briliant moves quiz"]
+          [ChapterName "Judit's Polgar brilliancy"]
+          [FEN "k6r/3p4/P1nq1p2/2b5/4Q1p1/2R5/1PP3PB/R6K w - - 0 1"]
+          [SetUp "1"]
+          [UTCDate "2025.04.27"]
+          [UTCTime "14:50:26"]
+          [Annotator "https://lichess.org/@/Deividukassss"]
+          [ChapterURL "https://lichess.org/study/dYxOPpbF/K9WVzSw8"]
+          [ChapterMode "gamebook"]
+
+          1. g3?? { This move leads from +5 for white to mate in four. Can you find it ? } 1... Rxh2+!! { Yes, absolutely gorgeous move. Can you find the continue for black? } 2. Kxh2 $7 Qd2+! { Yes. Absolutely correct. } 3. Kh1 Qh6+! 4. Kg2 $7 Qh3# $19 { Good job! } *
+          `}
+          flipped
         />
       </div>
     </>

--- a/src/components/PGNViewer/PGNViewer.tsx
+++ b/src/components/PGNViewer/PGNViewer.tsx
@@ -8,7 +8,6 @@ import { PGNViewerNotation } from "@/components/PGNViewer/PGNViewerNotation";
 import { useEngineAnalysis } from "@/lib/hooks/useEngineAnalysis";
 import { useToggle } from "@/lib/hooks/useToggle";
 import { useVariation } from "@/lib/hooks/useVariation";
-import { startFen } from "@/lib/types/pgnTypes";
 import { moveSoundPath } from "@/lib/types/types";
 import { makeVariationsNested, sideToMove } from "@/lib/utils/chessUtils";
 import { loadPgn } from "@/lib/utils/loadPgn";
@@ -50,10 +49,10 @@ export interface PGNViewerProps {
  */
 export function PGNViewer({
   pgn = "",
-  start = startFen,
+  start,
   flipped = false,
 }: PGNViewerProps) {
-  const mainVariation = loadPgn(pgn, start);
+  const { gameTree: mainVariation } = loadPgn(pgn, start);
 
   // Current state of display board
   const [flipState, flipBoard] = useToggle(flipped);

--- a/src/components/PGNViewer/__tests__/testPGNViewerNotation.tsx
+++ b/src/components/PGNViewer/__tests__/testPGNViewerNotation.tsx
@@ -7,7 +7,7 @@ import { loadPgn } from "@/lib/utils/loadPgn";
 import { PGNViewerNotation } from "../PGNViewerNotation";
 
 describe("Test PGNViewerNotation", () => {
-  const variation = loadPgn(
+  const { gameTree: variation } = loadPgn(
     "1. e4 e5 2. Nf3! [c2c3red] {Hello!} (2. d4?$13 (2. c3) exd4 (2...d6))",
     startFen,
   );
@@ -64,7 +64,10 @@ describe("Test PGNViewerNotation", () => {
   });
 
   test("Flat subvariations", () => {
-    const variation = loadPgn("1. e4 e5 (1...e6) (1...c5)", startFen);
+    const { gameTree: variation } = loadPgn(
+      "1. e4 e5 (1...e6) (1...c5)",
+      startFen,
+    );
     act(() =>
       root.render(
         <PGNViewerNotation {...{ variation, gameState, setGameState }} />,

--- a/src/lib/hooks/__tests__/testUseVariation.tsx
+++ b/src/lib/hooks/__tests__/testUseVariation.tsx
@@ -11,7 +11,7 @@ import { VariationState, useVariation } from "../useVariation";
 describe("Hooks/useVariation", () => {
   let result: { current: VariationState };
   beforeEach(() => {
-    const variationTree = loadPgn(
+    const { gameTree: variationTree } = loadPgn(
       "1. e4 e5 2. Nf3 (2. d4 (2. c3 Nf6 3. d4))",
       startFen,
     );
@@ -142,7 +142,10 @@ describe("Hooks/useVariation", () => {
   });
 
   test("Test multiple variations", () => {
-    const variationTree = loadPgn("1. e4 e5 (1... c5) (1... e6)", startFen);
+    const variationTree = loadPgn(
+      "1. e4 e5 (1... c5) (1... e6)",
+      startFen,
+    ).gameTree;
     ({ result } = renderHook(() => useVariation(variationTree)));
     const variations = result.current.variation.moves[1].variations;
     expect(variations.length).toBe(2);

--- a/src/lib/types/pgnTypes.tsx
+++ b/src/lib/types/pgnTypes.tsx
@@ -8,6 +8,12 @@ import { Chess, Square } from "chess.js";
 /** Array of arrows for react-chessboard */
 export type Arrows = Array<[Square, Square, string]>;
 
+/** PGN Variations and Metadata */
+export type PGNData = {
+  gameTree: Variation;
+  headers: Map<string, string>;
+};
+
 /** Tree of nested variations */
 export type Variation = {
   id: number;

--- a/src/lib/utils/__tests__/testChessUtils.tsx
+++ b/src/lib/utils/__tests__/testChessUtils.tsx
@@ -40,7 +40,7 @@ describe("Test Chess Utilities", () => {
     expect(fen).toBe(fenAfter);
   });
   test("Fen integration test", () => {
-    const variation = loadPgn("1. e4 e5 2. Nf3", startFen);
+    const variation = loadPgn("1. e4 e5 2. Nf3", startFen).gameTree;
     expect(getFen(variation, 3)).toBe(
       "rnbqkbnr/pppp1ppp/8/4p3/4P3/5N2/PPPP1PPP/RNBQKB1R b KQkq - 1 2",
     );
@@ -73,8 +73,8 @@ describe("Test Chess Utilities", () => {
       "1. e4 e5 (1...c5 (1... e6) 2. Nf3 (2. Nc3 (2. g3)))",
     ],
   ])("makeVariationsNested", (flatPgn, nestedPgn) => {
-    const result = makeVariationsNested(loadPgn(flatPgn, startFen));
-    const expected = loadPgn(nestedPgn, startFen);
+    const result = makeVariationsNested(loadPgn(flatPgn, startFen).gameTree);
+    const expected = loadPgn(nestedPgn, startFen).gameTree;
 
     expect(inspect(result)).toStrictEqual(inspect(expected));
   });


### PR DESCRIPTION
Parses PGN headers and returns a header dictionary in addition to the variations.

Sets main variation start position to header if not specified directly, or start position if neither is set.

Closes #36 