### PR TITLE
Add puzzle option to hide later moves to PGNViewer

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -14,7 +14,7 @@ export default function About() {
           [Opening "?"]
           [StudyName "Briliant moves quiz"]
           [ChapterName "Judit's Polgar brilliancy"]
-          [FEN "k6r/3p4/P1nq1p2/2b5/4Q1p1/2R5/1PP3PB/R6K w - - 0 1"]
+          [FEN "k6r/3p4/P1nq1p2/2b5/4Q1p1/2R3P1/1PP4B/R6K b - - 0 1"]
           [SetUp "1"]
           [UTCDate "2025.04.27"]
           [UTCTime "14:50:26"]
@@ -22,9 +22,10 @@ export default function About() {
           [ChapterURL "https://lichess.org/study/dYxOPpbF/K9WVzSw8"]
           [ChapterMode "gamebook"]
 
-          1. g3?? { This move leads from +5 for white to mate in four. Can you find it ? } 1... Rxh2+!! { Yes, absolutely gorgeous move. Can you find the continue for black? } 2. Kxh2 $7 Qd2+! { Yes. Absolutely correct. } 3. Kh1 Qh6+! 4. Kg2 $7 Qh3# $19 { Good job! } *
+          1... Rxh2+!! { Yes, absolutely gorgeous move. Can you find the continue for black? } 2. Kxh2 $7 Qd2+! { Yes. Absolutely correct. } 3. Kh1 Qh6+! 4. Kg2 $7 Qh3# $19 { Good job! } *
           `}
           flipped
+          puzzle="Black to mate in 4!"
         />
       </div>
     </>

--- a/src/components/PGNViewer/PGNViewer.tsx
+++ b/src/components/PGNViewer/PGNViewer.tsx
@@ -31,7 +31,7 @@ const VariationDisplayLength = 5;
 export interface PGNViewerProps {
   pgn?: string;
   start?: string;
-  puzzle?: boolean;
+  puzzle?: string;
   flipped?: boolean;
 }
 
@@ -51,6 +51,7 @@ export function PGNViewer({
   pgn = "",
   start,
   flipped = false,
+  puzzle = "",
 }: PGNViewerProps) {
   const { gameTree: mainVariation } = loadPgn(pgn, start);
 
@@ -148,6 +149,7 @@ export function PGNViewer({
               variation={mainVariation}
               gameState={{ variation, halfMoveNum }}
               setGameState={setGameState}
+              puzzle={puzzle}
             />
           }
         </div>

--- a/src/components/PGNViewer/PGNViewerNotation.tsx
+++ b/src/components/PGNViewer/PGNViewerNotation.tsx
@@ -14,9 +14,10 @@ import { moveIsGreat, moveIsMistake } from "@/lib/utils/chessUtils";
  */
 export interface PGNViewerNotationProps {
   variation: Variation;
-  gameState?: GameState;
+  gameState: GameState;
   setGameState?: (arg0: PGNStateCallback) => void;
   level?: number;
+  puzzle?: string;
 }
 
 // Styles
@@ -43,10 +44,23 @@ export function PGNViewerNotation({
   gameState,
   setGameState,
   level = 0,
+  puzzle = "",
 }: PGNViewerNotationProps) {
   // Loop through every move and build a JSX for the entire notation tree.
   const notationJSXElems = [];
   for (const [i, move] of variation.moves.entries()) {
+    if(puzzle && gameState?.halfMoveNum === 0 && level === 0) {
+      notationJSXElems.push(
+        <span
+          key={`Puzzle Comment ${i}`}
+          className="text-primary px-1 ml-[-3px] whitespace-pre-wrap"
+          aria-label={"Puzzle: " + puzzle}
+        >
+          {puzzle}
+        </span>
+      );
+      break;
+    }
     const isCurrentMove =
       variation.id === gameState?.variation.id &&
       i + 1 === gameState.halfMoveNum;
@@ -116,6 +130,10 @@ export function PGNViewerNotation({
         {move.variations.length > 0 ? <>) </> : ""}
       </Fragment>,
     );
+
+    if(puzzle && level === 0 && isCurrentMove) {
+      break;
+    }
   }
 
   return (

--- a/src/components/PGNViewer/__tests__/testPGNViewerNotation.tsx
+++ b/src/components/PGNViewer/__tests__/testPGNViewerNotation.tsx
@@ -24,6 +24,25 @@ describe("Test PGNViewerNotation", () => {
     );
   });
 
+  test("PGN Viewer Puzzle", () => {
+    act(() => root.render(<PGNViewerNotation {...{gameState, setGameState}} puzzle="Puzzle!" variation={variation} />))
+    // Already played moves should show.
+    const firstMove = getByLabelText(container, "Move: " + "1. e4");
+    expect(firstMove).toBeInTheDocument();
+
+    // Later moves should be hidden.
+    expect(() => getByLabelText(container, "2. Nf3!")).toThrow();
+  });
+
+  test("PGN Viewer Puzzle Comment", () => {
+    act(() => root.render(<PGNViewerNotation {...{gameState: {...gameState, halfMoveNum: 0}, setGameState}} puzzle="Puzzle!" variation={variation} />))
+    // No moves should show
+    expect(() => getByLabelText(container, "Move: " + "1. e4")).toThrow();
+    
+    // Puzzle Comment should show
+    expect(getByText(container, "Puzzle!")).toBeInTheDocument();
+  });
+
   test.each([
     ["1. e4", 1],
     ["e5", 2],

--- a/src/lib/utils/loadPgn.tsx
+++ b/src/lib/utils/loadPgn.tsx
@@ -19,7 +19,7 @@ const annotationLookup = [
   ["$16", "&plusmn;"],
   ["$17", "&mnplus;"],
   ["$18", "&plus;&#45;"],
-  ["$19", "&#45;&plus"],
+  ["$19", "&#45;&plus;"],
   ["$22", "&xodot"],
   ["$23", "&xodot"],
   ["$36", "&uarr;"],
@@ -52,7 +52,7 @@ const moveNumberRegex = /(?:[0-9]*\.+)?/;
 const moveRegex = /((?:[A-Za-z]+[0-9])|0-0-0|0-0|O-O-O|O-O)/;
 
 //Optional Annotations (!?=+- for direct annotation, e.g. $13 for pgn style notation)
-const annotationRegex = /((?:[/!?=+-]+ *|\$[0-9]+ *)*)?/;
+const annotationRegex = /((?:[#/!?=+-]+ *|\$[0-9]+ *)*)?/;
 
 // Arrows (in []), Comments (in {}), and Variations (in $(...$))
 // Order must always be arrows -> comments -> variations


### PR DESCRIPTION
Simple puzzle option that hides later moves.

Isn't a full playable puzzle, but is at least a basic functionality from a PGNViewer perspective.

A full puzzle component probably needs to use puzzle notation combined with a playable chessboard, but doesn't seem necessary right now.

Closes #23 , for now at least.