### PR TITLE
Made PGNViewerScrollable, cleaned up useVariation hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.2.4",
         "@radix-ui/react-label": "^2.1.6",
+        "@radix-ui/react-scroll-area": "^1.2.8",
         "@radix-ui/react-slot": "^1.2.2",
         "@types/mdx": "^2.0.13",
         "chess.js": "^1.1.0",
@@ -2028,10 +2029,48 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA=="
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
       "integrity": "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -2048,6 +2087,29 @@
       "integrity": "sha512-S/hv1mTlgcPX2gCTJrWuTjSXf7ER3Zf7zWGtOprxhIIY93Qin3n5VgNA0Ez9AgrK/lEtlYgzLd4f5x6AVar4Yw==",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -2086,6 +2148,36 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-scroll-area": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.8.tgz",
+      "integrity": "sha512-K5h1RkYA6M0Sn61BV5LQs686zqBsSC0sGzL4/Gw4mNnjzrQcGSc6YXfC6CRFNaGydSdv5+M8cb0eNsOGo0OXtQ==",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.2",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.2.tgz",
@@ -2093,6 +2185,34 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.2.4",
     "@radix-ui/react-label": "^2.1.6",
+    "@radix-ui/react-scroll-area": "^1.2.8",
     "@radix-ui/react-slot": "^1.2.2",
     "@types/mdx": "^2.0.13",
     "chess.js": "^1.1.0",

--- a/src/app/articles/openings/layout.tsx
+++ b/src/app/articles/openings/layout.tsx
@@ -4,11 +4,11 @@ export default function OpeningLayout({
   children: React.ReactNode;
 }) {
   return (
-    <div className="pb-20 flex flex-row-reverse gap-5">
-      <div className="flex flex-col min-w-1/4 items-end">
+    <div className="pb-20 flex flex-row-reverse gap-5 justify-center">
+      <div className="hidden md:flex flex-col min-w-1/4 items-end">
         <h5>Table Of Contents!</h5>
       </div>
-      <div className="flex flex-col">{children}</div>
+      <div className="flex flex-col max-w-3/4">{children}</div>
     </div>
   );
 }

--- a/src/components/PGNViewer/PGNViewer.tsx
+++ b/src/components/PGNViewer/PGNViewer.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useId } from "react";
 import { Chessboard } from "react-chessboard";
 
 import { PGNViewerButtons } from "@/components/PGNViewer/PGNViewerButtons";
@@ -13,7 +14,6 @@ import { makeVariationsNested, sideToMove } from "@/lib/utils/chessUtils";
 import { loadPgn } from "@/lib/utils/loadPgn";
 
 import { ChessBoardIcon } from "../ChessBoardIcon";
-import { useId } from "react";
 
 const MaxDepth = 21;
 const VariationDisplayLength = 5;
@@ -134,7 +134,11 @@ export function PGNViewer({
           />
         </div>
         <div className="w-5/12 flex flex-col p-1 pt-2 pl-2 lg:p-2 lg:pl-4 lg:pt-4 ">
-          <div aria-label="Notation Viewer" id={`notationScrollContainer${id}`} className="basis-0 grow overflow-y-auto">
+          <div
+            aria-label="Notation Viewer"
+            id={`notationScrollContainer${id}`}
+            className="basis-0 grow overflow-y-auto"
+          >
             <PGNViewerNotation
               id={id}
               variation={mainVariation}
@@ -158,7 +162,7 @@ export function PGNViewer({
             leftContainerStyle="justify-left items-center gap-2 xl:gap-4 pt-1 xl:pt-0"
           />
         </div>
-        
+
         <div className="w-5/12 flex flex-col justify-end gap-1 pl-4 pr-2 xl:pl-7 xl:pr-6">
           <div
             aria-label="stockfish-pv"

--- a/src/components/PGNViewer/PGNViewer.tsx
+++ b/src/components/PGNViewer/PGNViewer.tsx
@@ -13,6 +13,7 @@ import { makeVariationsNested, sideToMove } from "@/lib/utils/chessUtils";
 import { loadPgn } from "@/lib/utils/loadPgn";
 
 import { ChessBoardIcon } from "../ChessBoardIcon";
+import { useId } from "react";
 
 const MaxDepth = 21;
 const VariationDisplayLength = 5;
@@ -54,6 +55,7 @@ export function PGNViewer({
   puzzle = "",
 }: PGNViewerProps) {
   const { gameTree: mainVariation } = loadPgn(pgn, start);
+  const id = useId();
 
   // Current state of display board
   const [flipState, flipBoard] = useToggle(flipped);
@@ -114,13 +116,13 @@ export function PGNViewer({
 
   return (
     <div
-      className="flex border-primaryblack-light dark:border-primarywhite-dark border-solid border-3"
+      className="border-primaryblack-light dark:border-primarywhite-dark border-solid border-3"
       onKeyDown={handleKeyDown}
       tabIndex={-1}
       aria-label="PGN Viewer"
     >
-      <div className="w-3/5 h-full">
-        <div aria-hidden="true">
+      <div className="flex">
+        <div className="flex flex-col w-7/12" aria-hidden="true">
           <Chessboard
             position={fen()}
             arePiecesDraggable={false}
@@ -131,39 +133,43 @@ export function PGNViewer({
             }}
           />
         </div>
-        <PGNViewerButtons
-          leftButtons={[
-            { onClick: firstMove, children: "<<" },
-            { onClick: prevMove, children: "<" },
-            { onClick: nextMove, children: ">" },
-            { onClick: lastMove, children: ">>" },
-          ]}
-          rightButtons={[{ onClick: flipBoard, children: "Flip Board" }]}
-          leftContainerStyle="justify-left items-center gap-2 xl:gap-4 pt-1 xl:pt-0"
-        />
-      </div>
-      <div className="w-1/2 p-1 pt-2 pl-2 lg:p-2 lg:pl-4 lg:pt-4 flex flex-col justify-between items-end-safe">
-        <div aria-label="Notation Viewer" className="w-full mb-2 h-3/5">
-          {
+        <div className="w-5/12 flex flex-col p-1 pt-2 pl-2 lg:p-2 lg:pl-4 lg:pt-4 ">
+          <div aria-label="Notation Viewer" id={`notationScrollContainer${id}`} className="basis-0 grow overflow-y-auto">
             <PGNViewerNotation
+              id={id}
               variation={mainVariation}
               gameState={{ variation, halfMoveNum }}
               setGameState={setGameState}
               puzzle={puzzle}
             />
-          }
+          </div>
         </div>
-        <div className="flex flex-col justify-end font-semibold gap-1 min-w-1/2 px-3 xl:px-6">
+      </div>
+      <div className="flex pt-2">
+        <div className="flex-col w-7/12">
+          <PGNViewerButtons
+            leftButtons={[
+              { onClick: firstMove, children: "<<" },
+              { onClick: prevMove, children: "<" },
+              { onClick: nextMove, children: ">" },
+              { onClick: lastMove, children: ">>" },
+            ]}
+            rightButtons={[{ onClick: flipBoard, children: "Flip Board" }]}
+            leftContainerStyle="justify-left items-center gap-2 xl:gap-4 pt-1 xl:pt-0"
+          />
+        </div>
+        
+        <div className="w-5/12 flex flex-col justify-end gap-1 pl-4 pr-2 xl:pl-7 xl:pr-6">
           <div
             aria-label="stockfish-pv"
             hidden={!stockfishEnabled}
-            className="text-xs md:text-sm xl:text-base"
+            className="font-semibold text-xs lg:text-base xl:text-lg"
           >
             {stockfishData.pv}
           </div>
           <div
             className={
-              "flex items-center gap-1 lg:gap-2 xl:gap-3 text-xs lg:text-sm " +
+              "flex items-center font-semibold gap-1 lg:gap-2 xl:gap-3 text-xs lg:text-sm " +
               (stockfishEnabled ? "justify-between" : "justify-end")
             }
           >

--- a/src/components/PGNViewer/PGNViewerButtons.tsx
+++ b/src/components/PGNViewer/PGNViewerButtons.tsx
@@ -22,9 +22,9 @@ export interface PGNViewerButtonProps {
 }
 
 const defaultButtonStyle =
-  "text-lg md:text-xl hover:text-secondary-dark ring-1 px-2 md:rounded-2xl";
+  "text-lg md:text-xl hover:text-secondary-dark ring-1 px-1 sm:px-2 md:rounded-2xl";
 const defaultFlipButtonStyle =
-  "text-base md:text-lg hover:text-secondary-dark ";
+  "text-sm sm:text-base md:text-lg hover:text-secondary-dark ";
 const defaultFlexStyle = "justify-between items-center ";
 
 /**
@@ -59,7 +59,7 @@ export function PGNViewerButtons({
   };
 
   return (
-    <div className="flex justify-between p-1 lg:p-5 pr-0">
+    <div className="flex justify-between p-1 lg:p-5 pr-0 w-full">
       <div className={"flex " + leftContainerStyle}>
         {leftButtons.map(getButtons(true))}
       </div>

--- a/src/components/PGNViewer/PGNViewerNotation.tsx
+++ b/src/components/PGNViewer/PGNViewerNotation.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from "react";
+import { Fragment, useEffect } from "react";
 
 import { GameState, PGNStateCallback, Variation } from "@/lib/types/pgnTypes";
 import { moveIsGreat, moveIsMistake } from "@/lib/utils/chessUtils";
@@ -18,6 +18,7 @@ export interface PGNViewerNotationProps {
   setGameState?: (arg0: PGNStateCallback) => void;
   level?: number;
   puzzle?: string;
+  id?: string;
 }
 
 // Styles
@@ -27,7 +28,7 @@ const variationStylesByLevel = new Map([
   [-1, "text-xs lg:text-sm xl:text-base"],
 ]);
 const currentMoveStyle =
-  "font-bold text-primaryblack dark:text-primarywhite bg-secondary dark:bg-secondary-light rounded-lg border-1 shadow-md";
+  "text-black dark:text-white bg-secondary dark:bg-secondary-light rounded-lg shadow-md";
 
 /**
  * Component that displays a variation tree, with styling
@@ -45,6 +46,7 @@ export function PGNViewerNotation({
   setGameState,
   level = 0,
   puzzle = "",
+  id = ""
 }: PGNViewerNotationProps) {
   // Loop through every move and build a JSX for the entire notation tree.
   const notationJSXElems = [];
@@ -92,7 +94,7 @@ export function PGNViewerNotation({
           className={
             "px-1 py-0 sm:py-[1px] xl:py-[3px] cursor-pointer text-nowrap inline outline-none " +
             `${level > 0 && "italic"} ` +
-            `${(isCurrentMove && currentMoveStyle) || "border-none"} `
+            `${(isCurrentMove && currentMoveStyle + ` currentMove${id}`) || "border-transparent text-primaryblack-light dark:text-primarywhite"} `
           }
           onClick={clickHandler}
           aria-label={"Move: " + move_number + move_text}
@@ -135,6 +137,17 @@ export function PGNViewerNotation({
       break;
     }
   }
+
+  useEffect(() => {
+    const elems = document.getElementsByClassName(`currentMove${id}`);
+    for(let i = 0; i < elems.length; i++) {
+      const elem = elems[i] as HTMLButtonElement
+      const parentElem = document.getElementById(`notationScrollContainer${id}`);
+      if(elem && parentElem) {
+       parentElem.scrollTop = elem.offsetTop - parentElem.offsetTop - 50;
+      }
+    }
+  }, [variation, gameState, id]);
 
   return (
     <div

--- a/src/components/PGNViewer/PGNViewerNotation.tsx
+++ b/src/components/PGNViewer/PGNViewerNotation.tsx
@@ -46,7 +46,7 @@ export function PGNViewerNotation({
   setGameState,
   level = 0,
   puzzle = "",
-  id = ""
+  id = "",
 }: PGNViewerNotationProps) {
   // Loop through every move and build a JSX for the entire notation tree.
   const notationJSXElems = [];
@@ -140,11 +140,13 @@ export function PGNViewerNotation({
 
   useEffect(() => {
     const elems = document.getElementsByClassName(`currentMove${id}`);
-    for(let i = 0; i < elems.length; i++) {
-      const elem = elems[i] as HTMLButtonElement
-      const parentElem = document.getElementById(`notationScrollContainer${id}`);
-      if(elem && parentElem) {
-       parentElem.scrollTop = elem.offsetTop - parentElem.offsetTop - 50;
+    for (let i = 0; i < elems.length; i++) {
+      const elem = elems[i] as HTMLButtonElement;
+      const parentElem = document.getElementById(
+        `notationScrollContainer${id}`,
+      );
+      if (elem && parentElem) {
+        parentElem.scrollTop = elem.offsetTop - parentElem.offsetTop - 50;
       }
     }
   }, [variation, gameState, id]);

--- a/src/components/ui/scroll-area.tsx
+++ b/src/components/ui/scroll-area.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+
+import { cn } from "@/lib/utils"
+
+function ScrollArea({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>) {
+  return (
+    <ScrollAreaPrimitive.Root
+      data-slot="scroll-area"
+      className={cn("relative", className)}
+      {...props}
+    >
+      <ScrollAreaPrimitive.Viewport
+        data-slot="scroll-area-viewport"
+        className="focus-visible:ring-ring/50 size-full rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:outline-1"
+      >
+        {children}
+      </ScrollAreaPrimitive.Viewport>
+      <ScrollBar />
+      <ScrollAreaPrimitive.Corner />
+    </ScrollAreaPrimitive.Root>
+  )
+}
+
+function ScrollBar({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>) {
+  return (
+    <ScrollAreaPrimitive.ScrollAreaScrollbar
+      data-slot="scroll-area-scrollbar"
+      orientation={orientation}
+      className={cn(
+        "flex touch-none p-px transition-colors select-none",
+        orientation === "vertical" &&
+          "h-full w-2.5 border-l border-l-transparent",
+        orientation === "horizontal" &&
+          "h-2.5 flex-col border-t border-t-transparent",
+        className
+      )}
+      {...props}
+    >
+      <ScrollAreaPrimitive.ScrollAreaThumb
+        data-slot="scroll-area-thumb"
+        className="bg-border relative flex-1 rounded-full"
+      />
+    </ScrollAreaPrimitive.ScrollAreaScrollbar>
+  )
+}
+
+export { ScrollArea, ScrollBar }

--- a/src/lib/hooks/useVariation.tsx
+++ b/src/lib/hooks/useVariation.tsx
@@ -60,13 +60,12 @@ export function useVariation(
   // Use setGameState, but guarantee that result is a valid location of the move tree
   function setGameStateSafe(callback: PGNStateCallback): boolean {
     const newState = callback(gameState);
-    const success = (
+    const success =
       newState.variation &&
       newState.halfMoveNum >= 0 &&
       newState.halfMoveNum <= newState.variation.moves.length &&
-      newState != gameState
-    );
-    if(success) {
+      newState != gameState;
+    if (success) {
       setGameState((prevState) => callback(prevState));
     }
     return success;

--- a/src/lib/hooks/useVariation.tsx
+++ b/src/lib/hooks/useVariation.tsx
@@ -59,41 +59,29 @@ export function useVariation(
 
   // Use setGameState, but guarantee that result is a valid location of the move tree
   function setGameStateSafe(callback: PGNStateCallback): boolean {
-    let success = false;
-    setGameState((prevState) => {
-      const newState = callback(prevState);
-      if (
-        !newState.variation ||
-        newState.halfMoveNum < 0 ||
-        newState.halfMoveNum > newState.variation.moves.length ||
-        prevState === newState
-      ) {
-        return prevState;
-      }
-      success = true;
-      return newState;
-    });
+    const newState = callback(gameState);
+    const success = (
+      newState.variation &&
+      newState.halfMoveNum >= 0 &&
+      newState.halfMoveNum <= newState.variation.moves.length &&
+      newState != gameState
+    );
+    if(success) {
+      setGameState((prevState) => callback(prevState));
+    }
     return success;
   }
 
   // Finds and enters the next variation in the move tree, playing the move with sound
   function enterVariation() {
     return setGameStateSafe((prevState) => {
-      const variationMoves = prevState.variation.moves;
-      const initialMoveNum = prevState.halfMoveNum;
+      const moves = prevState.variation.moves;
+      const startIndex = Math.max(prevState.halfMoveNum - 1, 0);
       /* Find next variation if exists */
-      for (
-        let moveNum = Math.max(initialMoveNum - 1, 0);
-        moveNum < variationMoves.length;
-        moveNum++
-      ) {
-        if (variationMoves[moveNum].variations.length > 0) {
-          const variation = variationMoves[moveNum].variations[0];
-          return {
-            ...prevState,
-            variation,
-            halfMoveNum: 1,
-          };
+      for (let moveNum = startIndex; moveNum < moves.length; moveNum++) {
+        if (moves[moveNum].variations.length > 0) {
+          const variation = moves[moveNum].variations[0];
+          return { variation, halfMoveNum: 1 };
         }
       }
       return prevState;


### PR DESCRIPTION
- Refactored flex boxes to be flex columns nested around rows so that the sizing works correctly.

- Use a grow sizing hack to get the height of the notation to equal the chessboard height:
    ```
    <flex>
    <div flex flex-col> Chessboard </div>
    <div flex flex-col> <div grow basis-0 overflow-y-auto> Notation </div> </div>
    </flex>
   ```

  By using flex-cols like this, we can get the grow/basis to apply to the height instead of only the width, and it matches the height correctly so we can scroll.

- Used an effect to automatically scroll to the current move when it's updated.

- Refactored the useVariation hook because the stateSetter wasn't 100% pure (it set a variable), should be cleaner and safer now.

There are a few miscellaneous formatting changes to make everything look nice with the new PGNViewer JSX, but nothing major.