### PR TITLE
Fix layout shift when chessboard is slow to load.

### DIFF
--- a/src/app/articles/openings/layout.tsx
+++ b/src/app/articles/openings/layout.tsx
@@ -8,7 +8,7 @@ export default function OpeningLayout({
       <div className="hidden md:flex flex-col min-w-1/4 items-end">
         <h5>Table Of Contents!</h5>
       </div>
-      <div className="flex flex-col max-w-3/4">{children}</div>
+      <div className="flex flex-col">{children}</div>
     </div>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
         <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
           <EngineProvider>
             <div className="content flex flex-col min-h-screen justify-between items-center">
-              <div className="py-5 w-screen md:w-4/5 xl:w-2/3 flex flex-col gap-20 items-center">
+              <div className="py-5 w-5/6 md:w-4/5 xl:w-2/3 flex flex-col gap-20 items-center">
                 <Header />
                 <main>{children}</main>
               </div>

--- a/src/components/ChessBoard/PlayComputer.tsx
+++ b/src/components/ChessBoard/PlayComputer.tsx
@@ -81,7 +81,7 @@ export function PlayComputer({
   };
 
   return (
-    <div>
+    <div className="flex flex-col gap-4">
       <PlayableChessBoardStateless
         position={{ ...position, undoMove: handleUndo }}
         flipText="Switch Sides"

--- a/src/components/ChessBoard/PlayableChessBoard.tsx
+++ b/src/components/ChessBoard/PlayableChessBoard.tsx
@@ -28,18 +28,20 @@ export function PlayableChessBoardStateless({
   flipText?: string;
 }) {
   return (
-    <>
+    <div className="flex flex-col gap-2">
       <div className="border-primaryblack-light dark:border-primarywhite-dark border-solid border-3">
-        <Chessboard
-          position={position.position}
-          boardOrientation={position.flipped ? "black" : "white"}
-          onPieceDrop={position.makeMove}
-          animationDuration={0}
-          customArrowColor={"rgb(138, 12, 58)"}
-          customDropSquareStyle={{
-            boxShadow: "inset 0 0 3px 3px rgb(138, 12, 58)",
-          }}
-        />
+        <div className="flex before:pt-[100%]">
+          <Chessboard
+            position={position.position}
+            boardOrientation={position.flipped ? "black" : "white"}
+            onPieceDrop={position.makeMove}
+            animationDuration={0}
+            customArrowColor={"rgb(138, 12, 58)"}
+            customDropSquareStyle={{
+              boxShadow: "inset 0 0 3px 3px rgb(138, 12, 58)",
+            }}
+          />
+        </div>
       </div>
       <PGNViewerButtons
         leftButtonStyle={buttonStyles}
@@ -59,7 +61,7 @@ export function PlayableChessBoardStateless({
         ]}
         rightButtons={[{ onClick: position.toggleFlipped, children: flipText }]}
       />
-    </>
+    </div>
   );
 }
 

--- a/src/components/PGNViewer/PGNViewer.tsx
+++ b/src/components/PGNViewer/PGNViewer.tsx
@@ -54,7 +54,7 @@ export function PGNViewer({
   flipped = false,
   puzzle = "",
 }: PGNViewerProps) {
-  const { gameTree: mainVariation } = loadPgn(pgn, start);
+  const mainVariation = makeVariationsNested(loadPgn(pgn, start).gameTree);
   const id = useId();
 
   // Current state of display board
@@ -70,7 +70,7 @@ export function PGNViewer({
     enterVariation,
     exitVariation,
     setGameState,
-  } = useVariation(makeVariationsNested(mainVariation), moveSoundPath);
+  } = useVariation(mainVariation, moveSoundPath);
 
   // Engine State
   const [stockfishData, stockfishEnabled, setStockfishEnabled] =
@@ -116,22 +116,24 @@ export function PGNViewer({
 
   return (
     <div
-      className="border-primaryblack-light dark:border-primarywhite-dark border-solid border-3"
+      className="border-primaryblack-light dark:border-primarywhite-dark border-solid border-3 "
       onKeyDown={handleKeyDown}
       tabIndex={-1}
       aria-label="PGN Viewer"
     >
       <div className="flex">
         <div className="flex flex-col w-7/12" aria-hidden="true">
-          <Chessboard
-            position={fen()}
-            arePiecesDraggable={false}
-            boardOrientation={flipState ? "black" : "white"}
-            customArrows={arrows}
-            customBoardStyle={{
-              boxShadow: "3px 3px 5px rgba(0,0,0,.8)",
-            }}
-          />
+          <div className="flex before:pt-[100%]">
+            <Chessboard
+              position={fen()}
+              arePiecesDraggable={false}
+              boardOrientation={flipState ? "black" : "white"}
+              customArrows={arrows}
+              customBoardStyle={{
+                boxShadow: "3px 3px 5px rgba(0,0,0,.8)",
+              }}
+            />
+          </div>
         </div>
         <div className="w-5/12 flex flex-col p-1 pt-2 pl-2 lg:p-2 lg:pl-4 lg:pt-4 ">
           <div


### PR DESCRIPTION
Entire layout was shifting while waiting for react-chessboard.

Fix by wrapping it in:

```
<div className="flex before:pt-[100px]"> Chessboard </div>
```

This creates a pseudo element with a height (padding-top) of 100% of it's width. Given that react chessboard sets it's size using the container's width, this should be exactly the right size.